### PR TITLE
odroidc1: use boot part for kernel and config

### DIFF
--- a/classes/odroidc1-sdimg.bbclass
+++ b/classes/odroidc1-sdimg.bbclass
@@ -13,14 +13,14 @@ inherit image_types
 #                                                     Default Free space = 1.3x
 #                                                     Use IMAGE_OVERHEAD_FACTOR to add more space
 #                                                     <--------->
-#            4MiB                 SDIMG_ROOTFS
-# <-----------------------> <---------------------->
-#  ------------------------ ------------------------
-# | IMAGE_ROOTFS_ALIGNMENT | ROOTFS_SIZE            |
-#  ------------------------ ------------------------
-# ^                        ^                        ^
-# |                        |                        |
-# 0                      4MiB   SDIMG_ROOTFS
+#            4MiB              20MiB           SDIMG_ROOTFS
+# <-----------------------> <----------> <---------------------->
+#  ------------------------ ------------ ------------------------
+# | IMAGE_ROOTFS_ALIGNMENT | BOOT_SPACE | ROOTFS_SIZE            |
+#  ------------------------ ------------ ------------------------
+# ^                        ^            ^                        ^
+# |                        |            |                        |
+# 0                      4MiB     4MiB + 20MiB       4MiB + 20Mib + SDIMG_ROOTFS
 
 # This image depends on the rootfs image
 IMAGE_TYPEDEP_odroidc1-sdimg = "${SDIMG_ROOTFS_TYPE}"
@@ -71,18 +71,51 @@ IMAGE_CMD_odroidc1-sdimg () {
 	ROOTFS_SIZE_ALIGNED=$(expr ${ROOTFS_SIZE_ALIGNED} - ${ROOTFS_SIZE_ALIGNED} % ${IMAGE_ROOTFS_ALIGNMENT})
 	SDIMG_SIZE=$(expr ${IMAGE_ROOTFS_ALIGNMENT} + ${BOOT_SPACE_ALIGNED} + ${ROOTFS_SIZE_ALIGNED})
 
-	echo "Creating RootFS ${ROOTFS_SIZE_ALIGNED} KiB"
+	echo "Creating filesystem with Boot partition ${BOOT_SPACE_ALIGNED} KiB and RootFS ${ROOTFS_SIZE_ALIGNED} KiB"
 
 	# Initialize sdcard image file
 	dd if=/dev/zero of=${SDIMG} bs=1024 count=0 seek=${SDIMG_SIZE}
 
 	# Create partition table
 	parted -s ${SDIMG} mklabel msdos
+
+	# Create boot partition and mark it as bootable
+	parted -s ${SDIMG} unit KiB mkpart primary fat32 ${IMAGE_ROOTFS_ALIGNMENT} $(expr ${BOOT_SPACE_ALIGNED} \+ ${IMAGE_ROOTFS_ALIGNMENT})
+	parted -s ${SDIMG} set 1 boot on
+
 	# Create rootfs partition to the end of disk
-	parted -s ${SDIMG} -- unit KiB mkpart primary ext2 ${IMAGE_ROOTFS_ALIGNMENT} -1s
+	parted -s ${SDIMG} -- unit KiB mkpart primary ext2 $(expr ${BOOT_SPACE_ALIGNED} \+ ${IMAGE_ROOTFS_ALIGNMENT}) -1s
+
 	# Set boot flag
 	parted -s ${SDIMG} set 1 boot on
 	parted ${SDIMG} print
+
+	# Create a vfat image with boot files
+	BOOT_BLOCKS=$(LC_ALL=C parted -s ${SDIMG} unit b print | awk '/ 1 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
+	mkfs.vfat -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
+
+	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.ini ::boot.ini
+
+	case "${KERNEL_IMAGETYPE}" in
+	"uImage")
+		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin ::uImage
+		if test -n "${KERNEL_DEVICETREE}"; then
+ 		    mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${KERNEL_DEVICETREE} ::${KERNEL_DEVICETREE}
+		fi
+		;;
+	esac
+
+	if [ -n ${FATPAYLOAD} ] ; then
+		echo "Copying payload into VFAT"
+		for entry in ${FATPAYLOAD} ; do
+				# add the || true to stop aborting on vfat issues like not supporting .~lock files
+				mcopy -i ${WORKDIR}/boot.img -s -v ${IMAGE_ROOTFS}$entry :: || true
+		done
+	fi
+
+	# Add stamp file
+	echo "${IMAGE_NAME}-${IMAGEDATESTAMP}" > ${WORKDIR}/image-version-info
+	mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}//image-version-info ::
 
 	# Burn amlogic's intial bootloader BL1
 	dd if=${DEPLOY_DIR_IMAGE}/${BL1_SYMLINK} of=${SDIMG} bs=1 count=442 conv=notrunc
@@ -91,6 +124,13 @@ IMAGE_CMD_odroidc1-sdimg () {
 	# Burn u-boot
 	dd if=${DEPLOY_DIR_IMAGE}/${UBOOT_SYMLINK} of=${SDIMG} bs=512 seek=64 conv=notrunc
 
-	# Burn Partition
-	dd if=${SDIMG_ROOTFS} of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync
+	# Burn Partitions
+	dd if=${WORKDIR}/boot.img of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync
+	# If SDIMG_ROOTFS_TYPE is a .xz file use xzcat
+	if echo "${SDIMG_ROOTFS_TYPE}" | egrep -q "*\.xz"
+	then
+		xzcat ${SDIMG_ROOTFS} | dd of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync
+	else
+		dd if=${SDIMG_ROOTFS} of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync
+	fi
 }

--- a/recipes-bsp/u-boot/u-boot-odroidc1/odroidc1/boot.ini
+++ b/recipes-bsp/u-boot/u-boot-odroidc1/odroidc1/boot.ini
@@ -74,9 +74,9 @@ if test "${cec}" = "1"; then setenv hdmi_cec "hdmitx=cecf"; fi
 # bmp display ${loadaddr_logo}
 # bmp scale
 
-setenv bootargs "console=ttyS0,115200n8 console=tty0 root=/dev/mmcblk0p1 rootwait rw no_console_suspend vdaccfg=0xa000 logo=osd1,loaded,0x7900000,720p,full dmfc=3 cvbsmode=576cvbs hdmimode=${m} m_bpp=${m_bpp} vout=${vout_mode} ${disableuhs} ${hdmi_hpd} ${hdmi_cec}"
-ext4load mmc 0:1 0x21000000 /boot/uImage
-ext4load mmc 0:1 0x21800000 /boot/meson8b_odroidc.dtb
+setenv bootargs "console=ttyS0,115200n8 console=tty0 root=/dev/mmcblk0p2 rootwait rw no_console_suspend vdaccfg=0xa000 logo=osd1,loaded,0x7900000,720p,full dmfc=3 cvbsmode=576cvbs hdmimode=${m} m_bpp=${m_bpp} vout=${vout_mode} ${disableuhs} ${hdmi_hpd} ${hdmi_cec}"
+fatload mmc 0:1 0x21000000 uImage
+fatload mmc 0:1 0x21800000 meson8b_odroidc.dtb
 fdt addr 21800000
 
 if test "${vpu}" = "0"; then fdt rm /mesonstream; fdt rm /vdec; fdt rm /ppmgr; fi

--- a/recipes-bsp/u-boot/u-boot-odroidc1_2011.03.bb
+++ b/recipes-bsp/u-boot/u-boot-odroidc1_2011.03.bb
@@ -48,6 +48,7 @@ do_install_append () {
 }
 
 do_deploy_append () {
+    install ${WORKDIR}/boot.ini ${DEPLOYDIR}
     install ${S}/sd_fuse/${BL1_BINARY} ${DEPLOYDIR}/${BL1_IMAGE}
     cd ${DEPLOYDIR}
     rm -f ${BL1_BINARY} ${BL1_SYMLINK}


### PR DESCRIPTION
For conveinence concern, a boot part (FAT) is now used :
- to store and edit u-boot configuration file
- and store extra devices trees or kernel

It was inspired from raspberrypi setup script

Bug-Tizen: https://bugs.tizen.org/jira/browse/BTY-121
Origin: https://github.com/TizenTeam/meta-amlogic/#master
Change-Id: Ib6deb7b76d032920c4a166da794bedeac8eedefb
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>